### PR TITLE
fix: 处理私有序列Private SQ的的Value数据读取问题

### DIFF
--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 package debug
@@ -12,4 +13,8 @@ func Log(data string) {
 // Logf only logs with a formatted string when the debug build flag is present.
 func Logf(format string, args ...interface{}) {
 	log.Printf(format, args...)
+}
+
+func init() {
+	log.SetFlags(log.LstdFlags | log.Llongfile)
 }

--- a/pkg/debug/default.go
+++ b/pkg/debug/default.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package debug

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -60,6 +60,10 @@ func IsPrivate(group uint16) bool {
 	return group%2 == 1
 }
 
+func (t Tag) IsPrivate() bool {
+	return IsPrivate(t.Group)
+}
+
 // String returns a string of form "(0008,1234)", where 0x0008 is t.Group,
 // 0x1234 is t.Element.
 func (t Tag) String() string {
@@ -124,7 +128,7 @@ func GetVRKind(tag Tag, vr string) VRKind {
 		return VRItem
 	} else if tag == PixelData {
 		return VRPixelData
-	} else if tag.Group%2 != 0 {
+	} else if tag.IsPrivate() {
 		return VRPrivate
 	}
 

--- a/read.go
+++ b/read.go
@@ -509,6 +509,18 @@ func ioReadUntilPrivateSeqEnd2(r dicomio.Reader) (data []byte, n int, err error)
 			data = append(data, byte(b>>8))
 			continue
 		}
+		//读到结束码 要再读4个字节
+		if b, err := r.ReadUInt16(); err == nil {
+			n += 2
+			data = append(data, byte(b))
+			data = append(data, byte(b>>8))
+		}
+		if b, err := r.ReadUInt16(); err == nil {
+			n += 2
+			data = append(data, byte(b))
+			data = append(data, byte(b>>8))
+		}
+
 		return data, n, nil
 	}
 }

--- a/read_test.go
+++ b/read_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"strconv"
@@ -570,4 +571,19 @@ func buildTagData(t *testing.T, tg tag.Tag) []byte {
 	}
 
 	return data.Bytes()
+}
+
+func TestPeek(t *testing.T) {
+	bs := []byte{0xFF, 0xFE}
+	a := binary.LittleEndian.Uint16(bs)
+	fmt.Printf("%X\n", a)
+	if a == 0xFEFF {
+		fmt.Println("0xFFFE")
+	}
+	a = binary.BigEndian.Uint16(bs)
+	fmt.Printf("%X\n", a)
+	if a == 0xFFFE {
+		fmt.Println("0xFFFE")
+	}
+
 }


### PR DESCRIPTION
在读取到私有的SQ并且Length为-1时，采用一次读两个字节的方式循环读， 直到读到 FFFE,E0DD 的Sequence Delimitation Item